### PR TITLE
Speed up clustering

### DIFF
--- a/src/AI-HierarchicalClustering/AIClusteringData.class.st
+++ b/src/AI-HierarchicalClustering/AIClusteringData.class.st
@@ -81,7 +81,7 @@ AIClusteringData >> findMinimum [
 	"This method is written such that it uses primitives only."
 	
 	| columnVector |
-	value := AIUnlimited positive.
+	value := Float infinity.
 	2
 		to: indices size
 		do:

--- a/src/AI-HierarchicalClustering/AIClusteringVector.class.st
+++ b/src/AI-HierarchicalClustering/AIClusteringVector.class.st
@@ -34,16 +34,16 @@ AIClusteringVector >> min [
 
 { #category : #accessing }
 AIClusteringVector >> unsetAt: index [
-	super at: index put: AIUnlimited positive.
+	super at: index put: Float infinity.
 	found = index ifTrue: [ found := nil ]
 ]
 
 { #category : #private }
 AIClusteringVector >> update [
-	min := AIUnlimited positive.
-	self
-		doWithIndex: [ :each :ind | 
-			each < min
-				ifTrue: [ min := each.
-					found := ind ] ]
+
+	min := Float infinity.
+	self doWithIndex: [ :each :ind | "This was originally `each < min` but a lot of time we compare a float to an integer and it is faster to ask a float to compare itself to an integer than the other way around because it tries to cast the float as a fraction."
+		min >= each ifTrue: [
+			min := each.
+			found := ind ] ]
 ]

--- a/src/AI-HierarchicalClustering/AICorrelationVector.class.st
+++ b/src/AI-HierarchicalClustering/AICorrelationVector.class.st
@@ -50,7 +50,7 @@ AICorrelationVector >> defaultElement [
 AICorrelationVector >> min [
 	
 	^(self reject: #isNil)
-		inject: AIUnlimited positive
+		inject: Float infinity
 		into: [:each :min | min min: each]
 ]
 


### PR DESCRIPTION
This change has two goal. Reduce the usage of classes from Moose linear algebra. I'm using the infinite implementation of Float instead of AIUnlimited. And the second is to speed up the clustering but changing the order of comparison so that we cast less things.