### PR TITLE
Tool for comparing Pharo's hierarchical clustering with Python's, and fix to wards linkage

### DIFF
--- a/src/AI-HierarchicalClustering-Tests/AIClusterEngineTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusterEngineTest.class.st
@@ -2,12 +2,14 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIClusterEngineTest,
-	#superclass : #TestCase,
-	#category : #'AI-HierarchicalClustering-Tests-Core'
+	#name : 'AIClusterEngineTest',
+	#superclass : 'TestCase',
+	#category : 'AI-HierarchicalClustering-Tests-Core',
+	#package : 'AI-HierarchicalClustering-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClustering300Elements [
 
 	| input clusty clusters |
@@ -18,7 +20,7 @@ AIClusterEngineTest >> testClustering300Elements [
 	^ clusters
 ]
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClusteringWithAverageLinkage [
 
 	| input clusty clusters |
@@ -41,7 +43,7 @@ AIClusterEngineTest >> testClusteringWithAverageLinkage [
 	^ clusters
 ]
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClusteringWithCentroid [
 
 	| input clusty clusters |
@@ -64,7 +66,7 @@ AIClusterEngineTest >> testClusteringWithCentroid [
 	^ clusters
 ]
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClusteringWithCompleteLinkage [
 
 	| input clusty clusters |
@@ -87,7 +89,7 @@ AIClusterEngineTest >> testClusteringWithCompleteLinkage [
 	^ clusters
 ]
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClusteringWithMeanLinkage [
 
 	| input clusty clusters |
@@ -110,7 +112,7 @@ AIClusterEngineTest >> testClusteringWithMeanLinkage [
 	^ clusters
 ]
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClusteringWithSingleLinkage [
 
 	| input clusty clusters |
@@ -133,7 +135,7 @@ AIClusterEngineTest >> testClusteringWithSingleLinkage [
 	^ clusters
 ]
 
-{ #category : #'testing - clustering' }
+{ #category : 'testing - clustering' }
 AIClusterEngineTest >> testClusteringWithWardsMethod [
 	| input clusty clusters |
 	input := #(#(1 2 3 5) #(11 12 15) #(21 22 23 25) #(31 32 35) #(41 42 43 45 47)).
@@ -149,7 +151,7 @@ AIClusterEngineTest >> testClusteringWithWardsMethod [
 	^ clusters
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIClusterEngineTest >> testDendrogram [
 
 	| input clusty expected |
@@ -177,7 +179,7 @@ AIClusterEngineTest >> testDendrogram [
 	self assert: clusty dendrogram equals: expected
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIClusterEngineTest >> testDistanceMatrix [
 
     | input clusty |
@@ -186,7 +188,7 @@ AIClusterEngineTest >> testDistanceMatrix [
     self assert: clusty distanceMatrix equals: (AIDistanceSquare on: input)
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIClusterEngineTest >> testItems [
 
 	| input clusty |
@@ -195,7 +197,7 @@ AIClusterEngineTest >> testItems [
 	self assert: clusty items equals: input.
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIClusterEngineTest >> testSeriationEngine [
 	
 	| input output |

--- a/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
@@ -22,6 +22,13 @@ AIClusteringEngineComparisonTest >> datasets: anObject [
 	datasets := anObject
 ]
 
+{ #category : 'as yet unclassified' }
+AIClusteringEngineComparisonTest >> defaultFileLocation [
+	"Put here the absolute path to the directory where the datasets are stored"
+
+	^ nil
+]
+
 { #category : 'initialization' }
 AIClusteringEngineComparisonTest >> initialize [
 
@@ -47,13 +54,17 @@ AIClusteringEngineComparisonTest >> loadDatasets [
 
 	| circles moons blobs |
 	circles := (DataFrame
-		            readFromCsv: '/Users/poldurieux/circles_numpy.csv' asFileReference
+		            readFromCsv: (self defaultFileLocation , 'circles.csv') asFileReference
 		            withColumnNames: { 'x'. 'y' }
 		            separator: $,) collect: [ :row | row collect: #asNumber ].
-	moons := (DataFrame readFromCsv: '/Users/poldurieux/moons_numpy.csv' asFileReference withColumnNames: { 'x'. 'y' } separator: $,)
-		         collect: [ :row | row collect: #asNumber ].
-	blobs := (DataFrame readFromCsv: '/Users/poldurieux/blobs_numpy.csv' asFileReference withColumnNames: { 'x'. 'y' } separator: $,)
-		         collect: [ :row | row collect: #asNumber ].
+	moons := (DataFrame
+		          readFromCsv: (self defaultFileLocation , 'moons.csv') asFileReference
+		          withColumnNames: { 'x'. 'y' }
+		          separator: $,) collect: [ :row | row collect: #asNumber ].
+	blobs := (DataFrame
+		          readFromCsv: (self defaultFileLocation , 'blobs.csv') asFileReference
+		          withColumnNames: { 'x'. 'y' }
+		          separator: $,) collect: [ :row | row collect: #asNumber ].
 	^ {
 		  circles.
 		  moons.

--- a/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
@@ -80,10 +80,13 @@ AIClusteringEngineComparisonTest >> plot [
 	canvas := RSCanvas new.
 
 	datasets withIndexDo: [ :dataset :index |
+			| normalizedDataset |
+			normalizedDataset := dataset normalizedUsing: AIStandardizationNormalizer new.
+
 			linkageMethods do: [ :linkage |
 					| numberOfCluster clusty clusters compChart |
 					numberOfCluster := numbersOfClusters at: index.
-					clusty := AIClusterEngine with: dataset.
+					clusty := AIClusterEngine with: normalizedDataset.
 					clusty hierarchicalClusteringUsing: linkage.
 					clusters := clusty dendrogram breakInto: numberOfCluster.
 					compChart := RSCompositeChart new.

--- a/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
@@ -1,0 +1,99 @@
+Class {
+	#name : 'AIClusteringEngineComparisonTest',
+	#superclass : 'Object',
+	#instVars : [
+		'datasets',
+		'linkageMethods',
+		'numbersOfClusters'
+	],
+	#category : 'AI-HierarchicalClustering-Tests',
+	#package : 'AI-HierarchicalClustering-Tests'
+}
+
+{ #category : 'accessing' }
+AIClusteringEngineComparisonTest >> datasets [
+
+	^ datasets
+]
+
+{ #category : 'accessing' }
+AIClusteringEngineComparisonTest >> datasets: anObject [
+
+	datasets := anObject
+]
+
+{ #category : 'initialization' }
+AIClusteringEngineComparisonTest >> initialize [
+
+	datasets := self loadDatasets.
+	linkageMethods := { #singleLinkage. #averageLinkage. #completeLinkage. #wardsMethod }.
+	numbersOfClusters := { 3. 3. 3 }
+]
+
+{ #category : 'accessing' }
+AIClusteringEngineComparisonTest >> linkageMethods [
+
+	^ linkageMethods
+]
+
+{ #category : 'accessing' }
+AIClusteringEngineComparisonTest >> linkageMethods: anObject [
+
+	linkageMethods := anObject
+]
+
+{ #category : 'as yet unclassified' }
+AIClusteringEngineComparisonTest >> loadDatasets [
+
+	| circles moons blobs |
+	circles := (DataFrame
+		            readFromCsv: '/Users/poldurieux/circles_numpy.csv' asFileReference
+		            withColumnNames: { 'x'. 'y' }
+		            separator: $,) collect: [ :row | row collect: #asNumber ].
+	moons := (DataFrame readFromCsv: '/Users/poldurieux/moons_numpy.csv' asFileReference withColumnNames: { 'x'. 'y' } separator: $,)
+		         collect: [ :row | row collect: #asNumber ].
+	blobs := (DataFrame readFromCsv: '/Users/poldurieux/blobs_numpy.csv' asFileReference withColumnNames: { 'x'. 'y' } separator: $,)
+		         collect: [ :row | row collect: #asNumber ].
+	^ {
+		  circles.
+		  moons.
+		  blobs }
+]
+
+{ #category : 'accessing' }
+AIClusteringEngineComparisonTest >> numbersOfClusters [
+
+	^ numbersOfClusters
+]
+
+{ #category : 'accessing' }
+AIClusteringEngineComparisonTest >> numbersOfClusters: anObject [
+
+	numbersOfClusters := anObject
+]
+
+{ #category : 'rende' }
+AIClusteringEngineComparisonTest >> plot [
+
+	<script: 'self new plot open'>
+	| canvas layout |
+	canvas := RSCanvas new.
+
+	datasets withIndexDo: [ :dataset :index |
+			linkageMethods do: [ :linkage |
+					| numberOfCluster clusty clusters compChart |
+					numberOfCluster := numbersOfClusters at: index.
+					clusty := AIClusterEngine with: dataset.
+					clusty hierarchicalClusteringUsing: linkage.
+					clusters := clusty dendrogram breakInto: numberOfCluster.
+					compChart := RSCompositeChart new.
+					clusters do: [ :cluster | compChart add: (RSScatterPlot new x: (cluster collect: #first) y: (cluster collect: #second)) ].
+					compChart colors: NSScale category10.
+					compChart removeAllTicks.
+					index = 1 ifTrue: [ compChart title: linkage ].
+					canvas add: compChart asShape ] ].
+
+	layout := RSGridLayout on: canvas shapes.
+	canvas @ RSCanvasController.
+	^ canvas
+]

--- a/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
@@ -22,7 +22,7 @@ AIClusteringEngineComparisonTest >> datasets: anObject [
 	datasets := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'access' }
 AIClusteringEngineComparisonTest >> defaultFileLocation [
 	"Put here the absolute path to the directory where the datasets are stored"
 
@@ -49,7 +49,7 @@ AIClusteringEngineComparisonTest >> linkageMethods: anObject [
 	linkageMethods := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'load' }
 AIClusteringEngineComparisonTest >> loadDatasets [
 
 	| circles moons blobs |

--- a/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
@@ -27,7 +27,7 @@ AIClusteringEngineComparisonTest >> initialize [
 
 	datasets := self loadDatasets.
 	linkageMethods := { #singleLinkage. #averageLinkage. #completeLinkage. #wardsMethod }.
-	numbersOfClusters := { 3. 3. 3 }
+	numbersOfClusters := { 2. 2. 3 }
 ]
 
 { #category : 'accessing' }

--- a/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIClusteringEngineComparisonTest.class.st
@@ -1,3 +1,8 @@
+"
+This class is used to compare the behaviour of Pharo's hierarchical clustering with Python's behaviour on circles, moons and blobs datasets, using single, complete, average and wards linkages.
+For better comparison, datasets are created in Python and stored as csv files in the same folder. The datasets are loaded in Pharo with the loadDatasets method, and the clusterings are shown with the plot method.
+An example of Python script to generate and visualize clusterings can be found here: https://scikit-learn.org/stable/auto_examples/cluster/plot_linkage_comparison.html .
+"
 Class {
 	#name : 'AIClusteringEngineComparisonTest',
 	#superclass : 'Object',
@@ -22,7 +27,7 @@ AIClusteringEngineComparisonTest >> datasets: anObject [
 	datasets := anObject
 ]
 
-{ #category : 'access' }
+{ #category : 'accessing' }
 AIClusteringEngineComparisonTest >> defaultFileLocation [
 	"Put here the absolute path to the directory where the datasets are stored"
 
@@ -49,7 +54,7 @@ AIClusteringEngineComparisonTest >> linkageMethods: anObject [
 	linkageMethods := anObject
 ]
 
-{ #category : 'load' }
+{ #category : 'loading' }
 AIClusteringEngineComparisonTest >> loadDatasets [
 
 	| circles moons blobs |
@@ -83,7 +88,7 @@ AIClusteringEngineComparisonTest >> numbersOfClusters: anObject [
 	numbersOfClusters := anObject
 ]
 
-{ #category : 'rende' }
+{ #category : 'rendering' }
 AIClusteringEngineComparisonTest >> plot [
 
 	<script: 'self new plot open'>

--- a/src/AI-HierarchicalClustering-Tests/AIDendrogramTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIDendrogramTest.class.st
@@ -2,15 +2,17 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIDendrogramTest,
-	#superclass : #TestCase,
+	#name : 'AIDendrogramTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'dendrogram'
 	],
-	#category : #'AI-HierarchicalClustering-Tests-Core'
+	#category : 'AI-HierarchicalClustering-Tests-Core',
+	#package : 'AI-HierarchicalClustering-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 AIDendrogramTest >> setUp [
 	| ab cd ef abcd efg |
 	super setUp.
@@ -22,13 +24,13 @@ AIDendrogramTest >> setUp [
 	dendrogram := abcd merge: efg at: 7	"#(((a 1 b) 4 (c 2 d)) 7 ((e 3 f) 5 g))"
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDendrogramTest >> testAllLeaves [
 	self assert: dendrogram elements size equals: 7.
 	self assert: dendrogram elements equals: #(#a #b #c #d #e #f #g)
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDendrogramTest >> testIndex [
 	self assert: dendrogram index equals: 1.
 	self assert: dendrogram left index equals: 1.
@@ -39,7 +41,7 @@ AIDendrogramTest >> testIndex [
 	self assert: dendrogram right right index equals: 7
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDendrogramTest >> testSize [
 	self assert: dendrogram size equals: 7.
 	self assert: dendrogram left size equals: 4.

--- a/src/AI-HierarchicalClustering-Tests/AIDistanceSquareTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AIDistanceSquareTest.class.st
@@ -2,15 +2,17 @@
 A MLDistanceSquareTest is a test class for testing the behavior of MLDistanceSquare
 "
 Class {
-	#name : #AIDistanceSquareTest,
-	#superclass : #TestCase,
+	#name : 'AIDistanceSquareTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'distanceMatrix'
 	],
-	#category : #'AI-HierarchicalClustering-Tests-Math'
+	#category : 'AI-HierarchicalClustering-Tests-Math',
+	#package : 'AI-HierarchicalClustering-Tests',
+	#tag : 'Math'
 }
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> distanceSquare10Elements [
 	" Answer a distance square matrix of ten elements manually built "
 	
@@ -26,7 +28,7 @@ AIDistanceSquareTest >> distanceSquare10Elements [
 		
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> distanceSquare15Elements [
 	" Answer a distance square matrix of 15 elements manually built "
 	
@@ -43,13 +45,13 @@ AIDistanceSquareTest >> distanceSquare15Elements [
 		
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> matrixClass [
 	
 	^ AIDistanceSquare
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> testAtAndPut [
 
 	| validDs |
@@ -59,7 +61,7 @@ AIDistanceSquareTest >> testAtAndPut [
 
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> testCopyClusteringData [
 
 	| ds expected |
@@ -74,7 +76,7 @@ AIDistanceSquareTest >> testCopyClusteringData [
 
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> testDistanceBlock [
 
 	| ds |
@@ -85,7 +87,7 @@ AIDistanceSquareTest >> testDistanceBlock [
 	self assert: (ds distanceBlock isKindOf: BlockClosure).
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> testInitializeFrom1D [
 
 	| invalidItemsSizeCollection aMatrix |
@@ -102,7 +104,7 @@ AIDistanceSquareTest >> testInitializeFrom1D [
 	self should: [ aMatrix initializeFrom1D: invalidItemsSizeCollection ] raise: Error.
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> testItems [
 
 	| ds newItems |
@@ -115,7 +117,7 @@ AIDistanceSquareTest >> testItems [
 	self assert: ds items equals: newItems.
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> testNewVectorOfSizeItemsFromDimensions [
 
 	| ds vector |
@@ -133,7 +135,7 @@ AIDistanceSquareTest >> testNewVectorOfSizeItemsFromDimensions [
 	self assert: vector equals: (self vectorClass withAll: #(4 7 9 10 0)).
 ]
 
-{ #category : #test }
+{ #category : 'test' }
 AIDistanceSquareTest >> vectorClass [
 	
 	^ AIArrayVector

--- a/src/AI-HierarchicalClustering-Tests/AISimilarityItemTest.class.st
+++ b/src/AI-HierarchicalClustering-Tests/AISimilarityItemTest.class.st
@@ -2,12 +2,14 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AISimilarityItemTest,
-	#superclass : #TestCase,
-	#category : #'AI-HierarchicalClustering-Tests-Core'
+	#name : 'AISimilarityItemTest',
+	#superclass : 'TestCase',
+	#category : 'AI-HierarchicalClustering-Tests-Core',
+	#package : 'AI-HierarchicalClustering-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #'As yet unclassified' }
+{ #category : 'As yet unclassified' }
 AISimilarityItemTest >> testDistance [
 	| a b c elements engine clusters |
 	a := AIVectorItem with: #a and: #(1 0).
@@ -25,7 +27,7 @@ AISimilarityItemTest >> testDistance [
 	self assert: ((clusters select: [ :each | each size = 2 ]) first includes: b)
 ]
 
-{ #category : #'As yet unclassified' }
+{ #category : 'As yet unclassified' }
 AISimilarityItemTest >> testSimilarity [
 	| a b c elements engine clusters |
 	a := AISimilarityItem with: #a and: #(1 0).

--- a/src/AI-HierarchicalClustering-Tests/IntegerTest.extension.st
+++ b/src/AI-HierarchicalClustering-Tests/IntegerTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #IntegerTest }
+Extension { #name : 'IntegerTest' }
 
-{ #category : #'*AI-HierarchicalClustering-Tests' }
+{ #category : '*AI-HierarchicalClustering-Tests' }
 IntegerTest >> testFindNK [
 
 	self assert: 6 findNK equals:  #(6 1 6 5 4 2).

--- a/src/AI-HierarchicalClustering-Tests/package.st
+++ b/src/AI-HierarchicalClustering-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'AI-HierarchicalClustering-Tests' }
+Package { #name : 'AI-HierarchicalClustering-Tests' }

--- a/src/AI-HierarchicalClustering/AIClusterEngine.class.st
+++ b/src/AI-HierarchicalClustering/AIClusterEngine.class.st
@@ -2,97 +2,99 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIClusterEngine,
-	#superclass : #Object,
+	#name : 'AIClusterEngine',
+	#superclass : 'Object',
 	#instVars : [
 		'distanceMatrix',
 		'dendrogram'
 	],
-	#category : #'AI-HierarchicalClustering-Core'
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIClusterEngine class >> numbers: aCollection [
 	" AIClusterEngine numbers: #(1 2 9 0 7 2 4 3) "
 
 	^ (self with: aCollection using: [ :a :b | (a - b) * (a - b) ]) averageLinkage elements
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIClusterEngine class >> on1D: anObject [
 	" Answer a new instance of the receiver wrapping anObject as the receiver's distance matrix "
 
 	^ self withDistanceMatrix: (AIDistanceSquare on1D: anObject)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIClusterEngine class >> with: anObject [
 	" Answer a new instance of the receiver wrapping anObject as the receiver's distance matrix "
 
 	^ self withDistanceMatrix: (AIDistanceSquare on: anObject)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIClusterEngine class >> with: aCollection using: aDistanceBlock [
 	" Answer a new engine using aDistanceBlock containing the code to calculate distance between elements in aCollection "
 
 	^ self withDistanceMatrix: (AIDistanceSquare on: aCollection using: aDistanceBlock)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIClusterEngine class >> withDistanceMatrix: distanceMatrix [
 	^ self new
 		distanceMatrix: distanceMatrix;
 		yourself
 ]
 
-{ #category : #clustering }
+{ #category : 'clustering' }
 AIClusterEngine >> averageLinkage [
 	^ self performClustering: #averageLinkage
 ]
 
-{ #category : #clustering }
+{ #category : 'clustering' }
 AIClusterEngine >> completeLinkage [
 	^ self performClustering: #completeLinkage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusterEngine >> dendrogram [
 	^ dendrogram ifNil: [ dendrogram := self averageLinkage ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusterEngine >> distanceMatrix [
 	^ distanceMatrix
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusterEngine >> distanceMatrix: anObject [
 	distanceMatrix := anObject
 ]
 
-{ #category : #'private - deprecated' }
+{ #category : 'private - deprecated' }
 AIClusterEngine >> hierarchicalClusteringShowProgressUsing: selector [
 	self deprecated: 'Uses #hierarchicalClusteringUsing: instead'.
 	^ self hierarchicalClusteringUsing: selector
 ]
 
-{ #category : #'private - deprecated' }
+{ #category : 'private - deprecated' }
 AIClusterEngine >> hierarchicalClusteringUsing: selector [
 	^ self performClustering: selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusterEngine >> items [
 	^ distanceMatrix items
 ]
 
-{ #category : #clustering }
+{ #category : 'clustering' }
 AIClusterEngine >> performClustering: linkageSelector [
 	^ dendrogram := (AIClusteringData onDistanceSquare: distanceMatrix) performClustering: linkageSelector
 ]
 
-{ #category : #clustering }
+{ #category : 'clustering' }
 AIClusterEngine >> singleLinkage [
 	^ self performClustering: #singleLinkage
 ]

--- a/src/AI-HierarchicalClustering/AIClusteringData.class.st
+++ b/src/AI-HierarchicalClustering/AIClusteringData.class.st
@@ -9,7 +9,9 @@ Class {
 		'value',
 		'clusters',
 		'foundA0',
-		'foundB0'
+		'foundB0',
+		'nclusters',
+		'distanceMatrix'
 	],
 	#category : 'AI-HierarchicalClustering-Core',
 	#package : 'AI-HierarchicalClustering',
@@ -40,14 +42,14 @@ AIClusteringData class >> vectorSpecies [
 { #category : 'linkage functions' }
 AIClusteringData >> averageLinkage [
 	
-	| sizeA sizeB |
+	| weightA weightB sizeA sizeB |
 	sizeA := (clusters at: foundA0) size "asDouble"asFloat.
 	sizeB := (clusters at: foundB0) size "asDouble"asFloat.
-"	weightA := sizeA / (sizeA + sizeB).
-	weightB := sizeB / (sizeA + sizeB)."
+	weightA := sizeA / (sizeA + sizeB).
+	weightB := sizeB / (sizeA + sizeB).
 	self
 		privateLinkage:
-			[:index0 :valueA :valueB | (valueA / sizeA) min: (valueB / sizeB)]
+			[:index0 :valueA :valueB | valueA * weightA + (valueB * weightB)]
 ]
 
 { #category : 'linkage functions' }
@@ -182,10 +184,10 @@ AIClusteringData >> wardsMethod [
 	valueC := self at: foundA0 and: foundB0.
 	self
 		privateLinkage:
-			[:index0 :valueA :valueB | 
+			[:index0 :valueA :valueB |
 			sizeC := (clusters at: index0) size.
 			weightA := (sizeA + sizeC) / (sizeA + sizeB + sizeC).
 			weightB := (sizeB + sizeC) / (sizeA + sizeB + sizeC).
 			weightC := sizeC / (sizeA + sizeB + sizeC).
-			valueA * weightA + (valueB * weightB) - (valueC * weightC)]
+			(valueA squared * weightA + (valueB squared * weightB) - (valueC squared * weightC)) sqrt]
 ]

--- a/src/AI-HierarchicalClustering/AIClusteringData.class.st
+++ b/src/AI-HierarchicalClustering/AIClusteringData.class.st
@@ -9,9 +9,7 @@ Class {
 		'value',
 		'clusters',
 		'foundA0',
-		'foundB0',
-		'nclusters',
-		'distanceMatrix'
+		'foundB0'
 	],
 	#category : 'AI-HierarchicalClustering-Core',
 	#package : 'AI-HierarchicalClustering',

--- a/src/AI-HierarchicalClustering/AIClusteringData.class.st
+++ b/src/AI-HierarchicalClustering/AIClusteringData.class.st
@@ -2,8 +2,8 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIClusteringData,
-	#superclass : #AISymetricMatrix,
+	#name : 'AIClusteringData',
+	#superclass : 'AISymetricMatrix',
 	#instVars : [
 		'indices',
 		'value',
@@ -11,17 +11,19 @@ Class {
 		'foundA0',
 		'foundB0'
 	],
-	#category : #'AI-HierarchicalClustering-Core'
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusteringData class >> linkageFunctions [
 	" Answer a <Collection> of the receiver's available linkage functions selectors "
 	
 	^ self organization listAtCategoryNamed: #'linkage functions'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIClusteringData class >> onDistanceSquare: distanceSquare [
 	
 	^ self basicNew
@@ -29,26 +31,26 @@ AIClusteringData class >> onDistanceSquare: distanceSquare [
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIClusteringData class >> vectorSpecies [
 	
 	^Array
 ]
 
-{ #category : #'linkage functions' }
+{ #category : 'linkage functions' }
 AIClusteringData >> averageLinkage [
 	
-	| weightA weightB sizeA sizeB |
+	| sizeA sizeB |
 	sizeA := (clusters at: foundA0) size "asDouble"asFloat.
 	sizeB := (clusters at: foundB0) size "asDouble"asFloat.
-	weightA := sizeA / (sizeA + sizeB).
-	weightB := sizeB / (sizeA + sizeB).
+"	weightA := sizeA / (sizeA + sizeB).
+	weightB := sizeB / (sizeA + sizeB)."
 	self
 		privateLinkage:
-			[:index0 :valueA :valueB | valueA * weightA + (valueB * weightB)]
+			[:index0 :valueA :valueB | (valueA / sizeA) min: (valueB / sizeB)]
 ]
 
-{ #category : #'linkage functions' }
+{ #category : 'linkage functions' }
 AIClusteringData >> centroid [
 	
 	| weightA weightB sizeA sizeB valueC |
@@ -63,20 +65,20 @@ AIClusteringData >> centroid [
 			[:index0 :valueA :valueB | valueA * weightA + (valueB * weightB) - valueC]
 ]
 
-{ #category : #'linkage functions' }
+{ #category : 'linkage functions' }
 AIClusteringData >> completeLinkage [
 	
 	self privateLinkage: [:index0 :valueA :valueB | valueA max: valueB]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusteringData >> dendrogram [
 	" Answer an <AIDendrogramNode> representing the root node of the receiver's dendrogram "
 
 	^ clusters at: indices anyOne
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIClusteringData >> findMinimum [
 	"This method is written such that it uses primitives only."
 	
@@ -94,7 +96,7 @@ AIClusteringData >> findMinimum [
 					foundA0 := columnVector found]]
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIClusteringData >> initialize: distanceMatrix [
 	
 	partialColumns := distanceMatrix copyClusteringData
@@ -107,19 +109,19 @@ AIClusteringData >> initialize: distanceMatrix [
 		do: [:n | (partialColumns at: n) unsetAt: n]
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIClusteringData >> initializeRows: m columns: n [
 	
 	^self shouldNotImplement
 ]
 
-{ #category : #'linkage functions' }
+{ #category : 'linkage functions' }
 AIClusteringData >> meanLinkage [
 	
 	self privateLinkage: [:index0 :valueA :valueB | (valueA + valueB) / 2]
 ]
 
-{ #category : #clustering }
+{ #category : 'clustering' }
 AIClusteringData >> performClustering: linkageSelector [
 	
 	indices size - 1
@@ -130,7 +132,7 @@ AIClusteringData >> performClustering: linkageSelector [
 	^self dendrogram
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIClusteringData >> privateLinkage: aBlock [
 	
 	indices := indices copyRemoveAtIndex: (indices indexOf: foundB0).
@@ -157,13 +159,13 @@ AIClusteringData >> privateLinkage: aBlock [
 	clusters at: foundB0 put: nil
 ]
 
-{ #category : #'linkage functions' }
+{ #category : 'linkage functions' }
 AIClusteringData >> singleLinkage [
 	
 	self privateLinkage: [:index0 :valueA :valueB | valueA min: valueB]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIClusteringData >> unsetAt: row and: column [
 	
 	^row < column
@@ -171,7 +173,7 @@ AIClusteringData >> unsetAt: row and: column [
 		ifFalse: [(partialColumns at: row) unsetAt: column]
 ]
 
-{ #category : #'linkage functions' }
+{ #category : 'linkage functions' }
 AIClusteringData >> wardsMethod [
 	
 	| sizeA sizeB valueC sizeC weightA weightB weightC |

--- a/src/AI-HierarchicalClustering/AIClusteringVector.class.st
+++ b/src/AI-HierarchicalClustering/AIClusteringVector.class.st
@@ -2,17 +2,19 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIClusteringVector,
-	#superclass : #AIArrayVector,
-	#type : #variable,
+	#name : 'AIClusteringVector',
+	#superclass : 'AIArrayVector',
+	#type : 'variable',
 	#instVars : [
 		'min',
 		'found'
 	],
-	#category : #'AI-HierarchicalClustering-Math'
+	#category : 'AI-HierarchicalClustering-Math',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Math'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusteringVector >> at: index put: aNumber [
 	super at: index put: aNumber.
 	(found isNotNil and: [ found = index or: [ aNumber < min ] ])
@@ -20,25 +22,25 @@ AIClusteringVector >> at: index put: aNumber [
 	^ aNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusteringVector >> found [
 	
 	^found
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusteringVector >> min [
 	found ifNil: [ self update ].
 	^ min
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIClusteringVector >> unsetAt: index [
 	super at: index put: Float infinity.
 	found = index ifTrue: [ found := nil ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIClusteringVector >> update [
 
 	min := Float infinity.

--- a/src/AI-HierarchicalClustering/AICollectionItem.class.st
+++ b/src/AI-HierarchicalClustering/AICollectionItem.class.st
@@ -2,16 +2,18 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AICollectionItem,
-	#superclass : #Collection,
+	#name : 'AICollectionItem',
+	#superclass : 'Collection',
 	#instVars : [
 		'item',
 		'collection'
 	],
-	#category : #'AI-HierarchicalClustering-Core'
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 AICollectionItem >> add: newObject [
 	" *** This method was defined by Collection as a subclass responsibility.
 	Replace its body with a proper implementation. *** "
@@ -19,19 +21,19 @@ AICollectionItem >> add: newObject [
 	self error: 'Subclass responsibility stub not reimplemented'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICollectionItem >> collection [
 	
 	^collection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICollectionItem >> collection: anObject [
 	
 	collection := anObject
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AICollectionItem >> do: aBlock [
 	" *** This method was defined by Collection as a subclass responsibility.
 	Replace its body with a proper implementation. *** "
@@ -39,19 +41,19 @@ AICollectionItem >> do: aBlock [
 	self error: 'Subclass responsibility stub not reimplemented'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICollectionItem >> item [
 	
 	^item
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICollectionItem >> item: anObject [
 	
 	item := anObject
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 AICollectionItem >> remove: oldObject ifAbsent: anExceptionBlock [
 	" *** This method was defined by Collection as a subclass responsibility.
 	Replace its body with a proper implementation. *** "

--- a/src/AI-HierarchicalClustering/AICorrelationSquare.class.st
+++ b/src/AI-HierarchicalClustering/AICorrelationSquare.class.st
@@ -2,24 +2,26 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AICorrelationSquare,
-	#superclass : #AIDistanceSquare,
-	#category : #'AI-HierarchicalClustering-Math'
+	#name : 'AICorrelationSquare',
+	#superclass : 'AIDistanceSquare',
+	#category : 'AI-HierarchicalClustering-Math',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Math'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 AICorrelationSquare class >> defaultDistanceBlock [
 	
 	^[:a :b | a similarity: b]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AICorrelationSquare class >> vectorSpecies [
 	
 	^AICorrelationVector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AICorrelationSquare >> copyClusteringData [
 	
 	^partialColumns collect: [:each | each negated]

--- a/src/AI-HierarchicalClustering/AICorrelationVector.class.st
+++ b/src/AI-HierarchicalClustering/AICorrelationVector.class.st
@@ -2,19 +2,21 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AICorrelationVector,
-	#superclass : #AIVector,
-	#type : #bytes,
-	#category : #'AI-HierarchicalClustering-Math'
+	#name : 'AICorrelationVector',
+	#superclass : 'AIVector',
+	#type : 'bytes',
+	#category : 'AI-HierarchicalClustering-Math',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Math'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AICorrelationVector class >> new: size [
 	
 	^self basicNew: size << 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICorrelationVector >> at: anIndex [
 	"Answer a number between 1.0 and -1.0 at the given index.
 	The numbers are internally stored as 16-bit integer; and nil as zero."
@@ -26,7 +28,7 @@ AICorrelationVector >> at: anIndex [
 		ifFalse: [(short - 16r8000) asFloat / 16r7FFF]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICorrelationVector >> at: anIndex put: aNumber [
 	"Store a number between 1.0 and -1.0 at the given index.
 	The number is stores as 16-bit integer; nil is stored as zero."
@@ -40,13 +42,13 @@ AICorrelationVector >> at: anIndex put: aNumber [
 	^aNumber
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AICorrelationVector >> defaultElement [
 	
 	^nil
 ]
 
-{ #category : #'As yet unclassified' }
+{ #category : 'As yet unclassified' }
 AICorrelationVector >> min [
 	
 	^(self reject: #isNil)
@@ -54,20 +56,20 @@ AICorrelationVector >> min [
 		into: [:each :min | min min: each]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AICorrelationVector >> size [
 	
 	^self basicSize >> 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AICorrelationVector >> unsignedShortAt: byteIndex [
 	
 	<primitive: 540>
 	^self primitiveFailed
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AICorrelationVector >> unsignedShortAt: byteIndex put: anUnsignedShort [
 	
 	<primitive: 541>

--- a/src/AI-HierarchicalClustering/AIDendrogram.class.st
+++ b/src/AI-HierarchicalClustering/AIDendrogram.class.st
@@ -2,16 +2,18 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIDendrogram,
-	#superclass : #Collection,
+	#name : 'AIDendrogram',
+	#superclass : 'Collection',
 	#instVars : [
 		'parent',
 		'depth'
 	],
-	#category : #'AI-HierarchicalClustering-Dendrogram'
+	#category : 'AI-HierarchicalClustering-Dendrogram',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Dendrogram'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleAvgLinkageFromNumbers [
 	<example>
 	
@@ -19,7 +21,7 @@ AIDendrogram class >> exampleAvgLinkageFromNumbers [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleAvgLinkageFromNumbersInDataFrame [
 	<example>
 	
@@ -27,7 +29,7 @@ AIDendrogram class >> exampleAvgLinkageFromNumbersInDataFrame [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleAvgLinkageFromPoints [
 	<example>
 	
@@ -35,7 +37,7 @@ AIDendrogram class >> exampleAvgLinkageFromPoints [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleCentroidLinkageFromPoints [
 	<example>
 	
@@ -43,7 +45,7 @@ AIDendrogram class >> exampleCentroidLinkageFromPoints [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleCompleteLinkageFromPoints [
 	<example>
 	
@@ -51,7 +53,7 @@ AIDendrogram class >> exampleCompleteLinkageFromPoints [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleFromNumbersInDataFrameWithLinkage: aSelector [
 	<example>
 	
@@ -63,7 +65,7 @@ AIDendrogram class >> exampleFromNumbersInDataFrameWithLinkage: aSelector [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleFromNumbersWithLinkage: aSelector [
 	<example>
 	
@@ -75,7 +77,7 @@ AIDendrogram class >> exampleFromNumbersWithLinkage: aSelector [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleFromPointsWithLinkage: aSelector [
 	<example>
 	
@@ -87,7 +89,7 @@ AIDendrogram class >> exampleFromPointsWithLinkage: aSelector [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleMeanLinkageFromPoints [
 	<example>
 	
@@ -95,7 +97,7 @@ AIDendrogram class >> exampleMeanLinkageFromPoints [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleSingleLinkageFromPoints [
 	<example>
 	
@@ -103,7 +105,7 @@ AIDendrogram class >> exampleSingleLinkageFromPoints [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> exampleWardsFromPoints [
 	<example>
 	
@@ -111,7 +113,7 @@ AIDendrogram class >> exampleWardsFromPoints [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> sampleDataFrame [
 	" Answer a <DataFrame> of samples for examples "
 
@@ -169,7 +171,7 @@ Wyoming,6.8,161,60,15.6
 '
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> sampleNumbers [
 	" Answer a <Collection> of sample Numbers for examples "
 
@@ -177,7 +179,7 @@ AIDendrogram class >> sampleNumbers [
 
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 AIDendrogram class >> samplePoints [
 	" Answer a <Collection> of sample points for examples "
 
@@ -191,19 +193,19 @@ AIDendrogram class >> samplePoints [
 		}.
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDendrogram class >> with: anElement [
 	
 	^AIDendrogramLeaf with: anElement
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 AIDendrogram >> add: newObject [
 	
 	self shouldNotImplement
 ]
 
-{ #category : #'break into clusters' }
+{ #category : 'break into clusters' }
 AIDendrogram >> breakAtThreshold: aNumber [
 	
 	| candidates |
@@ -212,7 +214,7 @@ AIDendrogram >> breakAtThreshold: aNumber [
 	^candidates reject: [:each | candidates includes: each parent]
 ]
 
-{ #category : #'break into clusters' }
+{ #category : 'break into clusters' }
 AIDendrogram >> breakInto: numberOfClusters [
 	
 	| all candidates |
@@ -228,13 +230,13 @@ AIDendrogram >> breakInto: numberOfClusters [
 			candidates size >= numberOfClusters ifTrue: [^candidates asArray]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> depthFactor [
 
 	^ 20
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogram >> dist: dendrogram [
 	
 	| sum |
@@ -245,13 +247,13 @@ AIDendrogram >> dist: dendrogram [
 	^sum average
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogram >> do: aBlock [
 	
 	self elementsDo: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> elements [
 	
 	| stream |
@@ -260,19 +262,19 @@ AIDendrogram >> elements [
 	^stream contents
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogram >> elementsDo: aBlock [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> heightFactor [
 
 	^ 3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> index [
 	
 	^self isRoot
@@ -283,36 +285,36 @@ AIDendrogram >> index [
 				ifFalse: [self parent index + self parent left size]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogram >> isLeaf [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogram >> isLeft [
 	
 	^self parent left == self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogram >> isNode [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogram >> isRight [
 	
 	^self parent right == self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogram >> isRoot [
 	^ parent isNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> leaves [
 	
 	| stream |
@@ -321,25 +323,25 @@ AIDendrogram >> leaves [
 	^stream contents
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogram >> leavesDo: aBlock [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> left [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDendrogram >> merge: dendrogram at: threshold [
 	
 	^AIDendrogramNode with: self with: dendrogram at: threshold
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> nodes [
 	
 	| stream |
@@ -348,60 +350,60 @@ AIDendrogram >> nodes [
 	^stream contents
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogram >> nodesDo: aBlock [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogram >> orderLeafs [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> parent [
 	
 	^parent
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> parent: anObject [
 	parent := anObject
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 AIDendrogram >> remove: oldObject ifAbsent: anExceptionBlock [
 	
 	self shouldNotImplement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> right [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> size [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIDendrogram >> species [
 	
 	^OrderedCollection
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogram >> swap [
 	
 	^self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogram >> threshold [
 	
 	^self subclassResponsibility

--- a/src/AI-HierarchicalClustering/AIDendrogramLeaf.class.st
+++ b/src/AI-HierarchicalClustering/AIDendrogramLeaf.class.st
@@ -2,22 +2,24 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIDendrogramLeaf,
-	#superclass : #AIDendrogram,
+	#name : 'AIDendrogramLeaf',
+	#superclass : 'AIDendrogram',
 	#instVars : [
 		'element'
 	],
-	#category : #'AI-HierarchicalClustering-Dendrogram'
+	#category : 'AI-HierarchicalClustering-Dendrogram',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Dendrogram'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDendrogramLeaf class >> with: anElement [
 	^ self new
 		element: anElement;
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AIDendrogramLeaf >> = aMLDendrogram [
 
 	self == aMLDendrogram
@@ -27,87 +29,87 @@ AIDendrogramLeaf >> = aMLDendrogram [
 	^ self element = aMLDendrogram element
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramLeaf >> element [
 	
 	^element
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramLeaf >> element: anObject [
 	element := anObject
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogramLeaf >> elementsDo: aBlock [
 	
 	aBlock value: element
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AIDendrogramLeaf >> hash [ 
 
 	^ self element hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogramLeaf >> isLeaf [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 AIDendrogramLeaf >> keys [
 
 	^ self element keys
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogramLeaf >> leavesDo: aBlock [
 	
 	aBlock value: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramLeaf >> left [
 	
 	^self
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogramLeaf >> nodesDo: aBlock [
 	"does nothing"
 	
 	
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogramLeaf >> orderLeafs [
 	"do nothing"
 	
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramLeaf >> right [
 	
 	^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramLeaf >> size [
 	
 	^1
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogramLeaf >> swap [
 	"does nothing"
 	
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramLeaf >> threshold [
 	
 	^ Number zero

--- a/src/AI-HierarchicalClustering/AIDendrogramNode.class.st
+++ b/src/AI-HierarchicalClustering/AIDendrogramNode.class.st
@@ -2,17 +2,19 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIDendrogramNode,
-	#superclass : #AIDendrogram,
+	#name : 'AIDendrogramNode',
+	#superclass : 'AIDendrogram',
 	#instVars : [
 		'left',
 		'right',
 		'threshold'
 	],
-	#category : #'AI-HierarchicalClustering-Dendrogram'
+	#category : 'AI-HierarchicalClustering-Dendrogram',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Dendrogram'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDendrogramNode class >> with: left with: right at: threshold [
 
 	^ self new
@@ -22,7 +24,7 @@ AIDendrogramNode class >> with: left with: right at: threshold [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AIDendrogramNode >> = aMLDendrogram [
 
 	self == aMLDendrogram
@@ -34,46 +36,46 @@ AIDendrogramNode >> = aMLDendrogram [
 		 and: [ self threshold = aMLDendrogram threshold ] ]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogramNode >> elementsDo: aBlock [
 	
 	left elementsDo: aBlock.
 	right elementsDo: aBlock
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AIDendrogramNode >> hash [ 
 	"#hash is implemented, because #= is implemented"
 
 	^ self left hash bitXor: (self right hash bitXor: self threshold hash)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIDendrogramNode >> isNode [
 
 	^ true
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogramNode >> leavesDo: aBlock [
 	
 	left leavesDo: aBlock.
 	right leavesDo: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> left [
 	
 	^left
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> left: anObject [
 	left := anObject.
 	anObject parent: self
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AIDendrogramNode >> nodesDo: aBlock [
 	
 	aBlock value: self.
@@ -81,7 +83,7 @@ AIDendrogramNode >> nodesDo: aBlock [
 	right nodesDo: aBlock
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogramNode >> orderLeafs [
 	
 	| a b c d array |
@@ -104,25 +106,25 @@ AIDendrogramNode >> orderLeafs [
 	self right orderLeafs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> right [
 	
 	^right
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> right: anObject [
 	right := anObject.
 	anObject parent: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> size [
 	
 	^left size + right size
 ]
 
-{ #category : #seriation }
+{ #category : 'seriation' }
 AIDendrogramNode >> swap [
 	
 	| swap |
@@ -131,13 +133,13 @@ AIDendrogramNode >> swap [
 	right := swap
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> threshold [
 	
 	^threshold
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDendrogramNode >> threshold: anObject [
 	threshold := anObject
 ]

--- a/src/AI-HierarchicalClustering/AIDistanceSquare.class.st
+++ b/src/AI-HierarchicalClustering/AIDistanceSquare.class.st
@@ -2,17 +2,19 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIDistanceSquare,
-	#superclass : #AISymetricMatrix,
+	#name : 'AIDistanceSquare',
+	#superclass : 'AISymetricMatrix',
 	#instVars : [
 		'distanceBlock',
 		'items',
 		'dendrogram'
 	],
-	#category : #'AI-HierarchicalClustering-Math'
+	#category : 'AI-HierarchicalClustering-Math',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Math'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDistanceSquare class >> on1D: aCollection [
 	" Answer a new distance square matrix for aCollection of the receiver configured with a default distance "
 
@@ -21,7 +23,7 @@ AIDistanceSquare class >> on1D: aCollection [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDistanceSquare class >> on: anObject [
 	" Answer a new distance square matrix for anObject of the receiver configured with a default distance "
 
@@ -30,7 +32,7 @@ AIDistanceSquare class >> on: anObject [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDistanceSquare class >> on: vectorA and: vectorB using: distanceBlock [
 	
 	[vectorA size = vectorB size] assert.
@@ -39,7 +41,7 @@ AIDistanceSquare class >> on: vectorA and: vectorB using: distanceBlock [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIDistanceSquare class >> on: aCollection using: distanceBlock [
 	" Answer a new distance square matrix on aCollection items and with distanceBlock to obtain the distance between element vectors "
 
@@ -48,19 +50,19 @@ AIDistanceSquare class >> on: aCollection using: distanceBlock [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> at: row and: column put: aNumber [
 	
 	^self noModificationError
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> at: row at: column put: aNumber [
 	
 	(partialColumns at: row) at: column put: aNumber
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIDistanceSquare >> checkInvariant [
 	
 	^super checkInvariant
@@ -68,31 +70,31 @@ AIDistanceSquare >> checkInvariant [
 			[(distanceBlock respondsTo: #value:value:) and: [items isCollection]]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIDistanceSquare >> collectDendrogramItems [
 	
 	^ items asArrayOfRows collect: [ : item | AIDendrogram with: item ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIDistanceSquare >> copyClusteringData [
 	
 	^partialColumns collect: [:each | each copy]
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 AIDistanceSquare >> defaultDistanceBlock [
 	
 	^[:a :b | a dist: b]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> dendrogram [
 	dendrogram ifNil: [ self performSeriation ].
 	^ dendrogram
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> distanceBlock [
 	" Answer a <BlockClosure> with the default behavior for calculating distance between receiver's elements "
 
@@ -100,13 +102,13 @@ AIDistanceSquare >> distanceBlock [
 		ifNil: [ distanceBlock := self defaultDistanceBlock ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> distanceBlock: anObject [
 	
 	distanceBlock := anObject
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIDistanceSquare >> initialize: vectorA and: vectorB using: aDistanceBlock [
 	
 	items := nil.
@@ -122,7 +124,7 @@ AIDistanceSquare >> initialize: vectorA and: vectorB using: aDistanceBlock [
 						value: (vectorB at: row)]]
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIDistanceSquare >> initializeFrom1D: aCollection [
 	" Private - Assume aCollection to be 1D (flat) collection. Read items from it and set the receiver's lower triangular matrix "
 	
@@ -142,7 +144,7 @@ AIDistanceSquare >> initializeFrom1D: aCollection [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIDistanceSquare >> initializeFrom: anObject [
 	" Private - anObject should know how to initialize for the receiver's lower triangular items ."
 
@@ -152,7 +154,7 @@ AIDistanceSquare >> initializeFrom: anObject [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIDistanceSquare >> initializeFromDataFrame: aDataFrame [
 	" Private - Read items from aCollection and set the receiver's lower triangular items applying the distance formula between vectors in the data frame."
 
@@ -166,7 +168,7 @@ AIDistanceSquare >> initializeFromDataFrame: aDataFrame [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIDistanceSquare >> initializeFromNumbers: aCollection [
 	" Private - Assume aCollection to be 1D (flat) collection. Read items from it and set the receiver's lower triangular matrix "
 	
@@ -179,7 +181,7 @@ AIDistanceSquare >> initializeFromNumbers: aCollection [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 AIDistanceSquare >> initializeFromPoints: someItems [ 
 	
 	items := someItems.
@@ -190,7 +192,7 @@ AIDistanceSquare >> initializeFromPoints: someItems [
 				value: (items at: row) ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 AIDistanceSquare >> initializeFromVectorItems: aCollection [ 
 
 	items := aCollection.
@@ -201,18 +203,18 @@ AIDistanceSquare >> initializeFromVectorItems: aCollection [
 						value: (items at: row)]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> items [
 	
 	^items
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIDistanceSquare >> items: anObject [
 	items := anObject
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIDistanceSquare >> newVectorOfSize: i itemsFrom: aCollection dimensions: n [
 	" Private - Answer a new vector of i size with items from aCollection, read as condensed indices.
 	To get each element (from aCollection) in the new vector, the number of elements to the left and above is obtained for each position, depending of the dimensions of the whole receiver (a squareform matrix) and the requested vector size (each row in the current iteration) "
@@ -229,7 +231,7 @@ AIDistanceSquare >> newVectorOfSize: i itemsFrom: aCollection dimensions: n [
 	^ vector
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 AIDistanceSquare >> performSeriation [
 	| newOrder |
 	dendrogram := (AIClusterEngine withDistanceMatrix: self) averageLinkage.
@@ -237,7 +239,7 @@ AIDistanceSquare >> performSeriation [
 	self rearrange: newOrder
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIDistanceSquare >> rearrange: newItems [
 	
 	| newColumns indices |

--- a/src/AI-HierarchicalClustering/AIFeatureCollection.class.st
+++ b/src/AI-HierarchicalClustering/AIFeatureCollection.class.st
@@ -2,16 +2,18 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIFeatureCollection,
-	#superclass : #OrderedCollection,
-	#type : #variable,
+	#name : 'AIFeatureCollection',
+	#superclass : 'OrderedCollection',
+	#type : 'variable',
 	#instVars : [
 		'item'
 	],
-	#category : #'AI-HierarchicalClustering-Core'
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIFeatureCollection class >> item: anItem features: aCollection [
 	
 	^((self withAll: aCollection) sorted)
@@ -19,7 +21,7 @@ AIFeatureCollection class >> item: anItem features: aCollection [
 		yourself
 ]
 
-{ #category : #distance }
+{ #category : 'distance' }
 AIFeatureCollection >> chroniaHausdorffDistance: aFeatureCollection [
 	"Answer a modified hausdorff distance between myself and aFeatureCollection. 
 	Further information see 'How Developers Drive Software Evolution' (to be published at IWPSE 2005).
@@ -32,13 +34,13 @@ AIFeatureCollection >> chroniaHausdorffDistance: aFeatureCollection [
 	^distance value
 ]
 
-{ #category : #distance }
+{ #category : 'distance' }
 AIFeatureCollection >> dist: aFeatureCollection [
 	
 	^self hausdorffDistance: aFeatureCollection
 ]
 
-{ #category : #distance }
+{ #category : 'distance' }
 AIFeatureCollection >> hausdorffDistance: aFeatureCollection [
 	"Answer the hausdorff distance between myself and aFeatureCollection. 
 	Limitations of the implementation see FeatureCollection>>hausdorffMinima:."
@@ -50,7 +52,7 @@ AIFeatureCollection >> hausdorffDistance: aFeatureCollection [
 	^distance value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AIFeatureCollection >> hausdorffMinima: aFeatureCollection [
 	"Answer for each element in myself the distance to the nearest element in aFeatureCollection.
 	Assumes that the elements of both collections are sorted using an ordering that is compatible
@@ -69,19 +71,19 @@ AIFeatureCollection >> hausdorffMinima: aFeatureCollection [
 	^minima
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIFeatureCollection >> item [
 	
 	^item
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIFeatureCollection >> setItem: anObject [
 	
 	item := anObject
 ]
 
-{ #category : #distance }
+{ #category : 'distance' }
 AIFeatureCollection >> sizeDistance: aFeatureCollection [
 	
 	^self size dist: aFeatureCollection size

--- a/src/AI-HierarchicalClustering/AISeriationEngine.class.st
+++ b/src/AI-HierarchicalClustering/AISeriationEngine.class.st
@@ -2,21 +2,23 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AISeriationEngine,
-	#superclass : #Object,
+	#name : 'AISeriationEngine',
+	#superclass : 'Object',
 	#instVars : [
 		'elements'
 	],
-	#category : #'AI-HierarchicalClustering-Core'
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AISeriationEngine class >> applyOn: elements [
 	
 	^(self with: elements) defaultAlgorithm
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AISeriationEngine class >> with: elements [
 	
 	^(self new)
@@ -24,25 +26,25 @@ AISeriationEngine class >> with: elements [
 		yourself
 ]
 
-{ #category : #algorithm }
+{ #category : 'algorithm' }
 AISeriationEngine >> defaultAlgorithm [
 	
 	^self orderDendrogramLeaves
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AISeriationEngine >> elements [
 	
 	^elements
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AISeriationEngine >> elements: anObject [
 	
 	elements := anObject
 ]
 
-{ #category : #algorithm }
+{ #category : 'algorithm' }
 AISeriationEngine >> orderDendrogramLeaves [
 	
 	| clusty |

--- a/src/AI-HierarchicalClustering/AISimilarityItem.class.st
+++ b/src/AI-HierarchicalClustering/AISimilarityItem.class.st
@@ -2,18 +2,20 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AISimilarityItem,
-	#superclass : #AIVectorItem,
-	#category : #'AI-HierarchicalClustering-Math'
+	#name : 'AISimilarityItem',
+	#superclass : 'AIVectorItem',
+	#category : 'AI-HierarchicalClustering-Math',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Math'
 }
 
-{ #category : #'vector functions' }
+{ #category : 'vector functions' }
 AISimilarityItem >> dist: anItem [
 	
 	^1 - (self vector cosine: anItem vector)
 ]
 
-{ #category : #'distance functions' }
+{ #category : 'distance functions' }
 AISimilarityItem >> similarity: anItem [
 	
 	^self vector cosine: anItem vector

--- a/src/AI-HierarchicalClustering/AITimeWarpingEngine.class.st
+++ b/src/AI-HierarchicalClustering/AITimeWarpingEngine.class.st
@@ -2,35 +2,37 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AITimeWarpingEngine,
-	#superclass : #Object,
+	#name : 'AITimeWarpingEngine',
+	#superclass : 'Object',
 	#instVars : [
 		'vectorA',
 		'vectorB',
 		'distanceBlock'
 	],
-	#category : #'AI-HierarchicalClustering-Core'
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> distanceBlock [
 	
 	^distanceBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> distanceBlock: anObject [
 	
 	distanceBlock := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> getCost [
 	
 	^self getCostMatrix last
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 AITimeWarpingEngine >> getCostMatrix [
 	| cost matrix |
 	matrix := AIDistanceSquare on: vectorA and: vectorB using: self distanceBlock.
@@ -49,25 +51,25 @@ AITimeWarpingEngine >> getCostMatrix [
 	^ cost
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> vectorA [
 	
 	^vectorA
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> vectorA: anObject [
 	
 	vectorA := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> vectorB [
 	
 	^vectorB
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AITimeWarpingEngine >> vectorB: anObject [
 	
 	vectorB := anObject

--- a/src/AI-HierarchicalClustering/AIValueItem.class.st
+++ b/src/AI-HierarchicalClustering/AIValueItem.class.st
@@ -2,30 +2,32 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIValueItem,
-	#superclass : #Association,
-	#category : #'AI-HierarchicalClustering-Core'
+	#name : 'AIValueItem',
+	#superclass : 'Association',
+	#category : 'AI-HierarchicalClustering-Core',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Core'
 }
 
-{ #category : #'distance functions' }
+{ #category : 'distance functions' }
 AIValueItem >> dist: anItem [
 	
 	^self value dist: anItem value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIValueItem >> item [
 	
 	^self key
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIValueItem >> item: anObject [
 	
 	^self key: anObject
 ]
 
-{ #category : #'distance functions' }
+{ #category : 'distance functions' }
 AIValueItem >> similarity: anItem [
 	
 	^self value similarity: anItem value

--- a/src/AI-HierarchicalClustering/AIVectorItem.class.st
+++ b/src/AI-HierarchicalClustering/AIVectorItem.class.st
@@ -2,15 +2,17 @@
 Copyright (c), 2004-2007 Adrian Kuhn. This class is part of Hapax. Hapax is distributed under BSD License, see package comment.
 "
 Class {
-	#name : #AIVectorItem,
-	#superclass : #AIVectorDecorator,
+	#name : 'AIVectorItem',
+	#superclass : 'AIVectorDecorator',
 	#instVars : [
 		'item'
 	],
-	#category : #'AI-HierarchicalClustering-Math'
+	#category : 'AI-HierarchicalClustering-Math',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Math'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIVectorItem class >> with: anElement and: aVector [
 	
 	^(self on: aVector)
@@ -18,7 +20,7 @@ AIVectorItem class >> with: anElement and: aVector [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AIVectorItem class >> with: anElement andAll: aCollection [
 	
 	^(self on: (AIArrayVector withAll: aCollection))
@@ -26,51 +28,51 @@ AIVectorItem class >> with: anElement andAll: aCollection [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AIVectorItem >> = anObject [
 	
 	^super = anObject
 		or: [(anObject isKindOf: AIVectorItem) and: [self item = anObject item]]
 ]
 
-{ #category : #'vector functions' }
+{ #category : 'vector functions' }
 AIVectorItem >> dist: anItem [
 	
 	^self vector dist: anItem vector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 AIVectorItem >> initializeDistanceSquare: anAIDistanceSquare from: aCollection [ 
 	" Initialize anAIDistanceSquare based in the recever's element for aCollection items "
 
 	anAIDistanceSquare initializeFromVectorItems: aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIVectorItem >> item [
 	
 	^item
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIVectorItem >> item: anObject [
 	
 	item := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 AIVectorItem >> printOn: aStream [
 	
 	item printOn: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIVectorItem >> vector [
 	
 	^vector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AIVectorItem >> vector: anObject [
 	
 	vector := anObject

--- a/src/AI-HierarchicalClustering/ArrayedCollection.extension.st
+++ b/src/AI-HierarchicalClustering/ArrayedCollection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ArrayedCollection }
+Extension { #name : 'ArrayedCollection' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 ArrayedCollection >> asArrayOfRows [
 
 	^ self

--- a/src/AI-HierarchicalClustering/Collection.extension.st
+++ b/src/AI-HierarchicalClustering/Collection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Collection }
+Extension { #name : 'Collection' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 Collection >> cross: aCollection do: aBlock [
 
 	self do: [:each |

--- a/src/AI-HierarchicalClustering/DataFrame.extension.st
+++ b/src/AI-HierarchicalClustering/DataFrame.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DataFrame }
+Extension { #name : 'DataFrame' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 DataFrame >> initializeDistanceSquareFor: anAIDistanceSquare [
 	" Initialize anAIDistanceSquare matrix using the receiver's contents "
 

--- a/src/AI-HierarchicalClustering/Integer.extension.st
+++ b/src/AI-HierarchicalClustering/Integer.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Integer }
+Extension { #name : 'Integer' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 Integer >> findNK [
 
 	" Yields all n and k such that n take: k = self.
@@ -31,7 +31,7 @@ Integer >> findNK [
 				  choose := (choose / (n + 1 - k)) ceiling ] ] ]
 ]
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 Integer >> firstOver: k with: c [
     " Binary search to find smallest value of n for which n^k >= c "
 	| n lo hi mid |

--- a/src/AI-HierarchicalClustering/ManifestMLHierachicalClustering.class.st
+++ b/src/AI-HierarchicalClustering/ManifestMLHierachicalClustering.class.st
@@ -2,7 +2,9 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestMLHierachicalClustering,
-	#superclass : #PackageManifest,
-	#category : #'AI-HierarchicalClustering-Manifest'
+	#name : 'ManifestMLHierachicalClustering',
+	#superclass : 'PackageManifest',
+	#category : 'AI-HierarchicalClustering-Manifest',
+	#package : 'AI-HierarchicalClustering',
+	#tag : 'Manifest'
 }

--- a/src/AI-HierarchicalClustering/Number.extension.st
+++ b/src/AI-HierarchicalClustering/Number.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Number }
+Extension { #name : 'Number' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 Number >> initializeDistanceSquare: anAIDistanceSquare from: aCollection [ 
 	" Initialize anAIDistanceSquare based in the recever's element for aCollection items "
 

--- a/src/AI-HierarchicalClustering/Point.extension.st
+++ b/src/AI-HierarchicalClustering/Point.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Point }
+Extension { #name : 'Point' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 Point >> initializeDistanceSquare: anAIDistanceSquare from: aCollection [ 
 	" Initialize anAIDistanceSquare based in the recever's element for aCollection items "
 

--- a/src/AI-HierarchicalClustering/SequenceableCollection.extension.st
+++ b/src/AI-HierarchicalClustering/SequenceableCollection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SequenceableCollection }
+Extension { #name : 'SequenceableCollection' }
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 SequenceableCollection >> copyRemoveAtIndex: index [
 	"Return a copt of the receiver without the element at index."
 
@@ -19,14 +19,14 @@ SequenceableCollection >> copyRemoveAtIndex: index [
 	^newSequenceableCollection
 ]
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 SequenceableCollection >> initializeDistanceSquareFor: anAIDistanceSquare [
 	" Initialize anAIDistanceSquare matrix using the receiver's contents "
 
 	self anyOne initializeDistanceSquare: anAIDistanceSquare from: self
 ]
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 SequenceableCollection >> reverseSort: aSortBlock [
 	"-- yet another selector for #sortReverse: --"
 	"-- not deprecated, since both writings are reasonable --"
@@ -34,7 +34,7 @@ SequenceableCollection >> reverseSort: aSortBlock [
 	self sortReverse: aSortBlock.
 ]
 
-{ #category : #'*AI-HierarchicalClustering' }
+{ #category : '*AI-HierarchicalClustering' }
 SequenceableCollection >> sortReverse: aSortBlock [
 	"Sort the receiver in-place in reversed order using aSortBlock, which can be one
 	of: a closure with two agrument, a closure with one argument or a symbol."

--- a/src/AI-HierarchicalClustering/package.st
+++ b/src/AI-HierarchicalClustering/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'AI-HierarchicalClustering' }
+Package { #name : 'AI-HierarchicalClustering' }


### PR DESCRIPTION
The class `AIClusteringEngineComparisonTest` is used to compare the behaviour of Pharo's hierarchical clustering with Python's behaviour on circles, moons and blobs datasets, using single, complete, average and wards linkages.
For better comparison, datasets are created in Python and stored as csv files in the same folder. The datasets are loaded in Pharo with the `loadDatasets` method, and the clusterings are shown with the `plot` method.

With this, I found a difference on how wards method behave between Pharo and Python. With the fix I made to `AIClusteringData>>#wardsMethod`, Pharo's hierarchical clustering now gives the same result as Python's.